### PR TITLE
Only translate permissions if the key doesn't return an array.

### DIFF
--- a/src/Nova/Role.php
+++ b/src/Nova/Role.php
@@ -99,9 +99,9 @@ class Role extends Resource
             ,
             Checkboxes::make(__('Permissions'), 'prepared_permissions')->withGroups()->options(SpatiePermission::all()->map(function ($permission, $key) {
                 return [
-                    'group'  => __(ucfirst($permission->group)),
+                    'group'  => is_array(__(ucfirst($permission->group))) ? ucfirst($permission->group) : __(ucfirst($permission->group)),
                     'option' => $permission->name,
-                    'label'  => __($permission->name),
+                    'label'  => is_array(__($permission->name)) ? $permission->name : __($permission->name),
                 ];
             })->groupBy('group')->toArray())
             ,


### PR DESCRIPTION
My group names are similar with the names I use for my translate files.

For example I had a group Signup also a translate file signup.php, this broke the permissions overview. The changes I've made are backward compatible but also fix this problem.